### PR TITLE
Add chatwoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@
 - [campo](https://github.com/chloerei/campo) - A forum app - **using Rails 4.2** - [:earth_africa:](http://codecampo.com)
 - [canvas-lms](https://github.com/instructure/canvas-lms) - A learning management app - **using Rails 5.2**
 - [catarse](https://github.com/catarse/catarse) - A crowdfunding platform for creative projects - **using Rails 4.2** - [:earth_africa:](https://catarse.me/)
+- [chatwoot](https://github.com/chatwoot/chatwoot) - A simple and elegant live chat software - **using Rails 6.0**
 - [ciao](https://github.com/brotandgames/ciao) - A URL status checking app - **using Rails 6.0**
 - [coRM](https://github.com/SIGIRE/CoRM) - A customer relationship management app - **using Rails 3.2** - [:earth_africa:](http://www.corm.fr)
 - [coderwall (legacy)](https://github.com/coderwall/coderwall-legacy) - A social network app for software engineers - **using Rails 3.2**


### PR DESCRIPTION
Chatwoot is a simple and elegant live chat software. An opensource alternative to Intercom, Zendesk, Drift, Crisp etc.
https://www.chatwoot.com/