### PR TITLE
Remove deprecated GitHub jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Use the "Table on Contents" menu on the top-left corner to explore the list.
 
 ### Jobs
 
-- [GitHub Jobs](https://jobs.github.com/positions?description=Rails)
 - [Stack Overflow](https://stackoverflow.com/jobs/developer-jobs-using-ruby-on-rails)
 - [railsjobs on Reddit](https://www.reddit.com/r/railsjobs/)
 - [rails jobs on indeed.com](https://www.indeed.com/q-Ruby-On-Rails-jobs.html)


### PR DESCRIPTION
First of all, thanks for the cool project 👍

[GitHub jobs](https://jobs.github.com/) is deprecated so I suggest to remove it from the list of resources

<img width="963" alt="Screenshot 2021-08-17 at 13 52 13" src="https://user-images.githubusercontent.com/19417873/129695500-91e3393c-99b8-43d6-9c19-658e4de8691a.png">
