### PR TITLE
Add Liam ERD

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@
 - [Bencher](https://bencher.dev/) - A suite of continuous benchmarking tools designed to catch performance regressions in CI.
 - [rails-dashboard](https://github.com/y-takey/rails-dashboard) - A dev-tool to improve your rails log.
 - [Optic](https://github.com/opticdev/optic) - Optic automatically documents and tests your APIs.
+- [Liam ERD](https://liambx.com/) - Generate Beautiful ER-Diagrams from your schema.rb. Using ruby/prism WASM with Node.js.
 
 [Back to top][link_toc]
 


### PR DESCRIPTION
We are developing a new tool to generate ER diagrams from schema.rb. I would like to see [Liam ERD](https://liambx.com/) added to the list!

See Mastodon's ER diagram for an example!
https://liambx.com/erd/p/github.com/mastodon/mastodon/blob/main/db/schema.rb